### PR TITLE
Specify use of isoWeekday instead of weekday

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -11,6 +11,7 @@ const propTypes = {
   showDaysOfWeek: PropTypes.bool,
   showWeekSeparators: PropTypes.bool,
   firstDayOfWeek: PropTypes.number,
+  useIsoWeekday: PropTypes.bool,
   selectRange: PropTypes.bool,
   onPickDate: PropTypes.func,
   onPickRange: PropTypes.func,
@@ -23,6 +24,7 @@ const defaultProps = {
   showDaysOfWeek: true,
   showWeekSeparators: true,
   firstDayOfWeek: 0,
+  useIsoWeekday: false,
   selectRange: false,
   onPickDate: null,
   onPickRange: null,
@@ -91,15 +93,13 @@ class Calendar extends Component {
   }
 
   renderDaysOfWeek() {
-    const { firstDayOfWeek, forceFullWeeks, showWeekSeparators } = this.props;
+    const { useIsoWeekday, firstDayOfWeek, forceFullWeeks, showWeekSeparators } = this.props;
     const totalDays = forceFullWeeks ? 42 : 37;
 
     const days = [];
     range(firstDayOfWeek, totalDays + firstDayOfWeek).forEach(i => {
-      const day = moment()
-        .weekday(i)
-        .format('dd')
-        .charAt(0);
+      const momentDay = useIsoWeekday ? moment().isoWeekday(i) : moment().weekday(i);
+      const day = momentDay.format('dd').charAt(0);
 
       if (showWeekSeparators) {
         if (i % 7 === firstDayOfWeek && days.length) {


### PR DESCRIPTION
We found that some packages cause issues with moment's weekday method,
in particular Kronos. The issue would present itself as the week always beginning on a Tuesday, regardless of how we set the locale in moment. Specifying isoWeekday helps resolve the issue for now, although we'd still like to dig into Kronos and figure out the cause at some point.

I've added a boolean flag to `Calendar` allowing optional overriding of `weekday` with `isoWeekday`.