### PR TITLE
Fix weekdays' name in some languages

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -100,7 +100,7 @@ class Calendar extends Component {
     range(firstDayOfWeek, totalDays + firstDayOfWeek).forEach(i => {
       const day = moment()
         .weekday(i)
-        .format('dd')
+        .format('ddd')
         .charAt(0);
 
       if (showWeekSeparators) {


### PR DESCRIPTION
Just found that in some languages, like pt and pt-br the moment().weekday(i).format('dd').charAt(0); returns an ordinal number relative to the week's name (2ª, 3ª, 4ª...), causing a bug in the week's name. The 'ddd' format corrects this problem.